### PR TITLE
Move uglify-js and webpack to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,8 +27,10 @@
   },
   "homepage": "https://github.com/hacke2/vue-append#readme",
   "dependencies": {
+    "vue": "^2.3.2"
+  },
+  "devDependencies": {
     "uglify-js": "^2.8.22",
-    "vue": "^2.3.2",
     "webpack": "^2.5.0"
   }
 }


### PR DESCRIPTION
Projects that uses this package gets a warning for vulnerabilities when running `npm audit`, e.g. 

```
found 7 vulnerabilities (1 moderate, 6 high) in 329 scanned packages  
7 vulnerabilities require manual review. See the full report for details.
```

This PR will move `uglify-js` and `webpack` from `dependencies` to `devDependencies` to not include them in projects that uses `vue-append`. These packages are only used in development/build mode and should therefore not be installed as `dependencies`.

The result is no vulnerabilities in the projects (they're still in this package however, that's not going to change in this PR).
```
found 0 vulnerabilities
```